### PR TITLE
Solution to issue #4

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from discord_slash.model import SlashMessage
 from discord_slash.utils.manage_commands import create_choice, create_option
 from PIL import Image
 from PIL import ImageDraw  # For drawing elements
+import time
 
 try:
     import overpy
@@ -126,9 +127,18 @@ async def on_ready() -> None:
     print(" - " + "\n - ".join([f"{guild.name}: {guild.id}" for guild in client.guilds]))
 
 
+# I got annoyed by people using googlebad so often, so i implemented easter egg.
+recent_googles=set()
 # Google Bad
 @slash.slash(name="googlebad", description="Find your fate of using Google Maps.", guild_ids=guild_ids)  # type: ignore
 async def googlebad_command(ctx: SlashContext) -> None:
+    global recent_googles
+    time_now=time.time()
+    recent_googles=set(filter(lambda x: x>time_now-60, recent_googles)).union({time_now})
+    if len(recent_googles)>11:  # Called every 5 seconds.
+        recent_googles=set()
+        await ctx.send(random.choice(ohnos).replace("...", "Whenever you use `/googlebad` command,"))
+        return
     await ctx.send(random.choice(ohnos).replace("...", "Whenever you mention Google Maps,"))
 
 

--- a/main.py
+++ b/main.py
@@ -878,14 +878,20 @@ async def get_image_cluster(
 
 
 @client.event  # type: ignore
-async def on_reaction_add(reaction,user) -> None:
+async def on_raw_reaction_add(payload) -> None:
     # Probably needs testing. It should maybe remove bot's own message, 
-    # if someone reacts with waste backet emoji
-    # For safety reasons, it should also authenticate reacting user 
-    waste_basket='\U0001F5D1'
-    if reaction.message.author!=client.user or str(reaction.emoji)!=waste_basket:
+    # if someone reacts with wastebasket emoji
+    # For safety reasons, it should also authenticate reacting user
+    # Currently anyone can delete bot's message.
+    waste_basket=b'\xf0\x9f\x97\x91\xef\xb8\x8f'
+    if (payload.emoji.name.encode('utf8')!=waste_basket):
         return
-    reaction.message.delete
+    # Fetch message is rather slow operation, that's why it only takes place if user reacts with wastebasket
+    msg = await client.get_channel(payload.channel_id).fetch_message(payload.message_id)
+    # Safety check
+    if (msg.author!=client.user and msg.author!=payload.member):
+        return
+    await msg.delete()
 
 
 ### Inline linking ###

--- a/main.py
+++ b/main.py
@@ -868,7 +868,7 @@ async def on_message(msg: Message) -> None:
     # Run queries
 
     # TODO: Give a message upon stuff being 'not found', rather than just ignoring it.
-
+    errorlog=[]
     async with msg.channel.typing():
         # Create the messages
         embeds: list[Embed] = []
@@ -879,20 +879,20 @@ async def on_message(msg: Message) -> None:
                 try:
                     embeds.append(elm_embed(get_elm(elm_type, elm_id)))
                 except ValueError:
-                    pass
+                    errorlog.append((elm_type, elm_id))
 
         for changeset_ids in changesets:
             for changeset_id in changeset_ids:
                 try:
                     embeds.append(changeset_embed(get_changeset(changeset_id)))
                 except ValueError:
-                    pass
+                    errorlog.append((elm_type, elm_id))
 
         for username in users:
             try:
                 embeds.append(user_embed(get_user(get_id_from_username(username))))
             except ValueError:
-                pass
+                errorlog.append(('user', username))
 
         for map_frag in map_frags:
             zoom, lat, lon = frag_to_bits(map_frag)
@@ -910,6 +910,9 @@ async def on_message(msg: Message) -> None:
             await msg.channel.send(file=files[0], reference=msg)
             for file in files[1:]:
                 await msg.channel.send(file=file)
+        if len(errorlog) > 0:
+            for element_type, element_id in errorlog:
+            await msg.channel.send(f"Error occured while processing {element_type}/{element_id}.")
 
 
 ### Member count ###

--- a/main.py
+++ b/main.py
@@ -661,6 +661,7 @@ def user_embed(user: dict, extras: Iterable[str] = []) -> Embed:
         embed.add_field(name="Changesets", value=user["changesets"]["count"])
         embed.add_field(name="Traces", value=user["traces"]["count"])
         embed.add_field(name="Contributor Terms", value="Agreed" if user["contributor_terms"]["agreed"] else "Unknown")
+        embed.add_field(name="User since", value=user["account_created"][:10])
         if user["blocks"]["received"]["count"] > 0:
             embed.add_field(
                 name="Blocks",

--- a/main.py
+++ b/main.py
@@ -897,6 +897,12 @@ async def on_raw_reaction_add(payload) -> None:
     # Safety check
     if (msg.author!=client.user and msg.author!=payload.member):
         return
+    # Allow only users whom bot originally replied to.
+    if (msg.author==client.user and msg.reference):  # If bot replied to someone
+        if not msg.reference.fail_if_not_exists:  # If replied message exists
+            msg2 = await client.get_channel(msg.reference.channel_id).fetch_message(msg.reference.message_id)
+            if (msg2.author!=payload.member):  # If author of original message is not someone
+                return  # who added reaction.
     await msg.delete()
 
 

--- a/main.py
+++ b/main.py
@@ -877,6 +877,14 @@ async def get_image_cluster(
     return File("data/cluster.png")
 
 
+@client.event  # type: ignore
+async def on_reaction_add(reaction,user) -> None:
+    waste_basket='\U0001F5D1'
+    if reaction.message.author!=client.user or str(reaction.emoji)!=waste_basket:
+        return
+    reaction.message.delete
+
+
 ### Inline linking ###
 ELM_INLINE_REGEX = rf"{SS}(node|way|relation)(s? |\/)({POS_INT}(?:(?:, | and | or | )(?:{POS_INT}))*){SE}"
 CHANGESET_INLINE_REGEX = rf"{SS}(changeset)(?:s? |\/)({POS_INT}(?:(?:, | and | or | )(?:{POS_INT}))*){SE}"

--- a/main.py
+++ b/main.py
@@ -912,7 +912,7 @@ async def on_message(msg: Message) -> None:
                 await msg.channel.send(file=file)
         if len(errorlog) > 0:
             for element_type, element_id in errorlog:
-            await msg.channel.send(f"Error occured while processing {element_type}/{element_id}.")
+            await msg.channel.send(f"Error occurred while processing {element_type}/{element_id}.")
 
 
 ### Member count ###

--- a/main.py
+++ b/main.py
@@ -879,6 +879,9 @@ async def get_image_cluster(
 
 @client.event  # type: ignore
 async def on_reaction_add(reaction,user) -> None:
+    # Probably needs testing. It should maybe remove bot's own message, 
+    # if someone reacts with waste backet emoji
+    # For safety reasons, it should also authenticate reacting user 
     waste_basket='\U0001F5D1'
     if reaction.message.author!=client.user or str(reaction.emoji)!=waste_basket:
         return

--- a/main.py
+++ b/main.py
@@ -1039,8 +1039,9 @@ async def on_raw_reaction_add(payload) -> None:
     msg = await client.get_channel(payload.channel_id).fetch_message(payload.message_id)
     # Safety check
     if (msg.author != client.user and msg.author != payload.member):
-        return
-    # Allow only users whom bot originally replied to.
+        return  # Delete message only if it's made by bot or the user who reacted.
+    # Allow only users whom bot originally replied to delete message.
+    # This portion of if-statements is not tested.
     if (msg.author == client.user and msg.reference):  # If bot replied to someone
         if not msg.reference.fail_if_not_exists:  # If replied message exists
             msg2 = await client.get_channel(msg.reference.channel_id).fetch_message(msg.reference.message_id)
@@ -1111,7 +1112,7 @@ async def on_message(msg: Message) -> None:
         files: list[File] = []
         errorlog: list[Str] = []
 
-        for elm_type, elm_ids in elms:
+        for elm_type, elm_ids, separator in elms:
             for elm_id in elm_ids:
                 try:
                     embeds.append(elm_embed(get_elm(elm_type, elm_id)))
@@ -1120,7 +1121,8 @@ async def on_message(msg: Message) -> None:
                     errorlog.append((elm_type, elm_id))
 
         for changeset_ids in changesets:
-            for changeset_id in changeset_ids:
+            # changeset_ids = (<tuple: list of changesets>, <str: separator used>)
+            for changeset_id in changeset_ids[0]:
                 try:
                     embeds.append(changeset_embed(get_changeset(changeset_id)))
                 except ValueError:

--- a/main.py
+++ b/main.py
@@ -988,6 +988,10 @@ def render_elms_on_file(file, render_queue, frag):
             # Coord is now actual pixels, where line must be drawn on image.
             render_queue[seg_num][i] = coord
         # Draw segment onto image
+        # draw_node(render_queue[seg_num][0])
+        # for node_num in range(1,len(render_queue[seg_num])):
+        #     draw_line(render_queue[seg_num][node_num-1], render_queue[seg_num][node_num])
+        #     draw_node(render_queue[seg_num][node_num])
     # I don't know how to draw lines in PIL
 
 

--- a/main.py
+++ b/main.py
@@ -1008,7 +1008,7 @@ def draw_node(coord, draw, colour='red'):
     draw.ellipse(twoPointList, fill=colour)
 
 
-def render_elms_on_cluster(Cluster, render_queue, frag, image):
+def render_elms_on_cluster(Cluster, render_queue, frag):
     # Inputs:   Cluster - PIL image
     #           render_queue - [[(lat, lon), ...], ...]
     #           frag  - zoom, lat, lon used  for cluster rendering input.
@@ -1154,9 +1154,9 @@ async def on_message(msg: Message) -> None:
             bbox = get_render_queue_bounds(render_queue)
             zoom, lat, lon = calc_preview_area(bbox)
             cluster, errors=await get_image_cluster(lat, lon, zoom)
-            File(map_save_path)
             errorlog+=errors
-            cluster=render_elms_on_cluster(cluster, render_queue, (zoom, lat, lon), image)
+            cluster=render_elms_on_cluster(cluster, render_queue, (zoom, lat, lon))
+            file=File(map_save_path)
             files.append(file)
 
         for username in users:

--- a/main.py
+++ b/main.py
@@ -386,7 +386,7 @@ def elms_to_render(elem_type='relation', elem_id='60189'):
 
 
 def get_render_queue_bounds(queue):
-    min_lat, max_lat, min_lon, max_lat=90,-90,180,-180
+    min_lat, max_lat, min_lon, max_lon=90,-90,180,-180
     precision=5
     for segment in queue:
         for coordinates in segment:
@@ -408,10 +408,11 @@ def calc_preview_area(queue_bounds):
     # Output: tuple (int(zoom), float(lat), float(lon))
     # Based on old showmap function and https://wiki.openstreetmap.org/wiki/Zoom_levels
     # Finds map area, that should contain all elements.
+    min_lat, max_lat, min_lon, max_lon=queue_bounds
     tiles_x, tiles_y = 5, 5
     delta_lat=max_lat-min_lat
     delta_lon=max_lon-min_lon
-    zoom_x=int(math.log2((360/delta_lon)*tiles_x) # That was easy
+    zoom_x=int(math.log2((360/delta_lon)*tiles_x)) # That was easy
     center=delta_lat/2+min_lat, delta_lon/2+min_lon
     zoom_y=22
     while (deg2tile(min_lat, 0, zoom_y)[1]-deg2tile(max_lat, 0,zoom_y)[1]+1)>tiles_y:

--- a/main.py
+++ b/main.py
@@ -727,7 +727,7 @@ def frag_to_bits(URL: str) -> tuple[int, float, float]:
     return int(zoom), float(lat), float(lon)
 
 
-def bits_to_frag(match: tuple[int, float, float]): -> str
+def bits_to_frag(match: tuple[int, float, float]) -> str:
     zoom, lat, lon = match
     return f"#map={zoom}/{lat}/{lon}"
 
@@ -739,7 +739,7 @@ def deg2tile(lat_deg: float, lon_deg: float, zoom: int): -> tuple[int, int]
     return tuple(map(int, deg2tile_float(lat_deg, lon_deg, zoom)))
 
 
-def tile2deg(zoom: int, x: int, y: int): -> tuple[float, float]
+def tile2deg(zoom: int, x: int, y: int) -> tuple[float, float]:
     # Gets top-left coordinate of tile.
     lat_rad = math.pi - 2 * math.pi * y / (2 ** zoom)
     lat_rad = 2 * math.atan(math.exp(lat_rad)) - math.pi / 2
@@ -750,7 +750,7 @@ def tile2deg(zoom: int, x: int, y: int): -> tuple[float, float]
     return (lat, lng)
 
 
-def deg2tile_float(lat_deg: float, lon_deg: float, zoom: int): -> tuple[int, int]
+def deg2tile_float(lat_deg: float, lon_deg: float, zoom: int) -> tuple[int, int]:
     # This is not really supposed to work, but it works.
     # By removing rounding down from deg2tile function, we can estimate
     # position where to draw coordinates during element export.
@@ -766,7 +766,7 @@ def deg2tile_float(lat_deg: float, lon_deg: float, zoom: int): -> tuple[int, int
     return (xtile, max(min(n - 1, ytile), 0))
 
 
-def elms_to_render(elem_type: str, elem_id: str | int, no_reduction=False: bool): -> list[list[tuple[float, float]]]
+def elms_to_render(elem_type: str, elem_id: str | int, no_reduction=False: bool) -> list[list[tuple[float, float]]]:
     # Inputs:   element_type (node / way / relation)
     #           elem_id     element's OSM ID as string
     # Queries OSM element geometry via overpass API.
@@ -843,7 +843,7 @@ def merge_segments(segments: list[list[tuple[float, float]]]): -> list[list[tupl
     return segments
 
 
-def reduce_segment_nodes(segments: list[list[tuple[float, float]]]): -> list[list[tuple[float, float]]]
+def reduce_segment_nodes(segments: list[list[tuple[float, float]]]) -> list[list[tuple[float, float]]]:
     # Relative simple way to reduce nodes by just picking every n-th node.
     # Ignores ways with less than 50 nodes.
     # Excel equivalent is =IF(A1<50;A1;SQRT(A1-50)+50)
@@ -896,7 +896,7 @@ def get_render_queue_bounds(segments: list[list[tuple[float, float]]]): -> tuple
     return (min_lat, max_lat, min_lon, max_lon)
 
 
-def calc_preview_area(queue_bounds: tuple[float, float, float, float]): -> tuple[int, float, float]
+def calc_preview_area(queue_bounds: tuple[float, float, float, float]) -> tuple[int, float, float]:
     # Input: tuple (min_lat, max_lat, min_lon, max_lon)
     # Output: tuple (int(zoom), float(lat), float(lon))
     # Based on old showmap function and https://wiki.openstreetmap.org/wiki/Zoom_levels
@@ -1008,7 +1008,7 @@ def draw_line(segment: list[tuple[float, float]], draw, colour='red'): -> None
     draw.line(segment, fill=colour, width=2)
 
 
-def draw_node(coord: tuple[float, float], draw, colour='red'): -> None
+def draw_node(coord: tuple[float, float], draw, colour='red') -> None:
     # https://stackoverflow.com/questions/2980366
     r = 3
     x, y = coord

--- a/main.py
+++ b/main.py
@@ -306,10 +306,11 @@ def get_elm(elm_type: str, elm_id: str | int) -> dict:
     return elm
 
 
-def elms_to_render(elem_type='relation', elem_id='60189'):
+def elms_to_render(elem_type, elem_id):
     # Default value uses russia as example
+    # Example: elms_to_render('relation', '60189')  (Russia)
     # Possible alternative approach to rendering is creating very rough drawing on bot-side.
-    # Using overpass to query just geometry. Such as (for Sweden)
+    # Using overpass to query just geometry.
     # And then draw just very few nodes onto map retrieved by showmap of zoom level 1..9
     # Even easier alternative is drawing bounding box
     # Throws IndexError if element was not found
@@ -412,9 +413,9 @@ def calc_preview_area(queue_bounds):
     tiles_x, tiles_y = 5, 5
     delta_lat=max_lat-min_lat
     delta_lon=max_lon-min_lon
-    zoom_x=int(math.log2((360/delta_lon)*tiles_x)) # That was easy
+    zoom_x=int(math.log2((360/delta_lon)*tiles_x))
     center=delta_lat/2+min_lat, delta_lon/2+min_lon
-    zoom_y=22
+    zoom_y=22  # Zoom level is determined by trying to fit x/y bounds into 5 tiles.
     while (deg2tile(min_lat, 0, zoom_y)[1]-deg2tile(max_lat, 0,zoom_y)[1]+1)>tiles_y:
         zoom_y-=1  # Very slow and dumb approach
     zoom=min(zoom_x, zoom_y, 19)
@@ -610,7 +611,7 @@ def changeset_embed(changeset: dict, extras: Iterable[str] = []) -> Embed:
         icon_url=config["icon_url"],
     )
 
-    # There dosen't appear to be a changeset icon
+    # There doesn't appear to be a changeset icon
     # embed.set_thumbnail(url=config["symbols"]["changeset"])
 
     embed.timestamp = str_to_date(changeset["closed_at"])
@@ -639,7 +640,7 @@ def changeset_embed(changeset: dict, extras: Iterable[str] = []) -> Embed:
     #     "&scale=1800&format=png"
     # )
     # embed.set_image(url=img_url)
-    # Easiest way to handle changeset rendering is to just draw bounding box.
+    # Easiest way to handle changeset rendering is to just draw bounding box to top tile.
 
     #### Fields ####
     if "info" in extras:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 python-dotenv
 discord.py
 discord-py-slash-command>=1.1.0
+overpy


### PR DESCRIPTION
This pull request implements issue #4 in less disruptive manner by requiring user to react with 🔎 if they use formatting like `nodes 1, 2 and 3` or `changeset 123 or 321`. Normal `way/258` is not affected.

I also reworked map bounding box logic behind /showmap to generate constant size of image and also resolved few issues with it's corner cases such as `#map=1/1.2/0.0`. Then added basic geometry query function in case you wish to draw elements on map in the future. Latter needs overPy module module to run basic overpass query to get geometry of an element.

Finally implemented what you mentioned in discord, reacting with 🗑️ to bot's message will delete it. However it doesn't have user authentication, so anyone can delete any bot message and nobody would find out.

And latest addition was about 80% of code needed to render elements. Missing bit is actual drawing, because I'm not familiar with PIL.