### PR TITLE
Round taginfo usage to 2 decimal places

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,7 +216,7 @@ def taginfo_embed(key: str, value: str | None = None) -> Embed:
     embed.add_field(
         # This gets the emoji. Removes "s" from the end if it is there to do this.
         name=config["emoji"][d["type"] if d["type"][-1] != "s" else d["type"][:-1]] + " " + d["type"],
-        value=(f"{d['count']} - {d['count_fraction']*100}%" + (f"\n{d['values']} values" if not value else ""))
+        value=(f"{d['count']} - {round(d['count_fraction']*100,2)}%" + (f"\n{d['values']} values" if not value else ""))
         if d["count"] > 0
         else "*None*",
         inline=False,
@@ -226,7 +226,7 @@ def taginfo_embed(key: str, value: str | None = None) -> Embed:
         embed.add_field(
             # This gets the emoji. Removes "s" from the end if it is there to do this.
             name=config["emoji"][d["type"] if d["type"][-1] != "s" else d["type"][:-1]] + " " + d["type"],
-            value=(f"{d['count']} - {d['count_fraction']*100}%" + (f"\n{d['values']} values" if not value else ""))
+            value=(f"{d['count']} - {round(d['count_fraction']*100,2)}%" + (f"\n{d['values']} values" if not value else ""))
             if d["count"] > 0
             else "*None*",
             inline=True,


### PR DESCRIPTION
Note: I know virtually no python, just did this by looking at stackoverflow. No guarantees this will work.

This fixes rounding errors such as this:
![image](https://user-images.githubusercontent.com/26827848/116002145-9da15300-a5f8-11eb-8a96-df1dea1e3005.png)


Signed-off-by: Atrate <Atrate@protonmail.com>